### PR TITLE
fix stock behavior, add debug configuration

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,10 +5,10 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "g++ - Build and debug active file",
+      "name": "g++ - run a.exe",
       "type": "cppdbg",
       "request": "launch",
-      "program": "${fileDirname}/a.out",
+      "program": "${fileDirname}/a.exe",
       "args": [],
       "stopAtEntry": false,
       "cwd": "${workspaceFolder}",
@@ -22,8 +22,7 @@
           "ignoreFailures": true
         }
       ],
-      "preLaunchTask": "C/C++: g++ build active file",
-      "miDebuggerPath": "/mingw64/bin/gdb"
+      "miDebuggerPath": "C:\\msys64\\mingw64\\bin\\gdb.exe"
     }
   ]
 }

--- a/src/xp/stock_delta.cpp
+++ b/src/xp/stock_delta.cpp
@@ -15,12 +15,11 @@ class Stock {
   float low;
   float close;
   uint64_t volume;
-  uint16_t open_delta;
+  int16_t open_delta;  // Convert to signed int, instead of using neg bit
   uint16_t high_delta;
   uint16_t low_delta;
   uint16_t close_delta;
   uint16_t volume_approximate;
-  char neg_bit : 6;
   bool empty_stock : 1;
   bool first_day : 1;
 
@@ -34,25 +33,29 @@ class Stock {
         open_delta(0),
         high_delta(0),
         low_delta(0),
-        close_delta('0'),
+        close_delta(0),
         volume_approximate(0),
-        empty_stock(1),
-        first_day(0) {}
+        empty_stock(true),
+        first_day(false) {}
+
+  // Remove negative bit
   friend ostream& operator<<(ostream& o, const Stock& t) {
     if (t.first_day) {
-      return o << t.neg_bit << " " << setprecision(5) << t.open_price << " "
-               << t.high_delta << " " << t.low_delta << " " << t.close_delta
-               << " " << t.volume_approximate << '\n';
-    } else {
-      return o << t.neg_bit << " " << t.open_delta << " " << t.high_delta << " "
+      return o << setprecision(5) << t.open_price << " " << t.high_delta << " "
                << t.low_delta << " " << t.close_delta << " "
                << t.volume_approximate << '\n';
+    } else {
+      return o << t.open_delta << " " << t.high_delta << " " << t.low_delta
+               << " " << t.close_delta << " " << t.volume_approximate << '\n';
     }
   }
+
+  // Make sure first_day is false, set true in delta()
   friend istream& operator>>(istream& i, Stock& t) {
     char symbol[32];
     char buf[1024];
     t.empty_stock = false;
+    t.first_day = false;
     i.getline(buf, sizeof(buf));
     uint32_t mm, dd, yyyy;
     double decOpen, decHi, decLow, decClose;
@@ -62,16 +65,20 @@ class Stock {
            &t.high, &t.low, &t.close, &t.volume, &openInterest);
     return i;
   }
-  void delta(Stock prev_day = Stock()) {
-    if (prev_day.isEmpty()) {
+
+  // Change default to nullptr instead of empty stock,
+  void delta(Stock* prev_day = nullptr) {
+    if (prev_day == nullptr) {
       first_day = true;
     }
-    double open_delta_double = open_price - prev_day.get_close_price();
+    // Since prev_day defaults to null, check if it exists
+    double prev_day_close =
+        (!prev_day) ? open_price : prev_day->get_close_price();
+    double open_delta_double = open_price - prev_day_close;
     double high_delta_double = high - open_price;
     double low_delta_double = open_price - low;
     double close_delta_double = close - low;
     int decimal = 5;
-    neg_bit = (open_delta_double < 0) + 48;
     open_delta = open_delta_double * pow(10, decimal);
     high_delta = high_delta_double * pow(10, decimal);
     low_delta = low_delta_double * pow(10, decimal);
@@ -81,6 +88,19 @@ class Stock {
 
   float get_close_price() { return close; }
   bool isEmpty() { return empty_stock; }
+
+  // Writes stock out to ostream as bits to be read in later
+  friend void binwrite(ofstream& o, const Stock& s) {
+    if (s.first_day)  // write base price if first_day, else write delta
+      o.write((char*)&s.open_price, sizeof(float));
+    else
+      o.write((char*)&s.open_delta, sizeof(int16_t));
+
+    o.write((char*)&s.high_delta, sizeof(uint16_t));
+    o.write((char*)&s.low_delta, sizeof(uint16_t));
+    o.write((char*)&s.close_delta, sizeof(uint16_t));
+    o.write((char*)&s.volume_approximate, sizeof(uint16_t));
+  }
 };
 
 class Compress_stock {
@@ -96,8 +116,8 @@ class Compress_stock {
     Stock s;
 
     while (f >> s) {
-      if (stocks.size() > 1)
-        s.delta(stocks[stocks.size() - 1]);
+      if (stocks.size() > 0)
+        s.delta(&stocks[stocks.size() - 1]);
       else
         s.delta();
       stocks.push_back(s);
@@ -105,9 +125,17 @@ class Compress_stock {
   };
   friend ostream& operator<<(ostream& o, const Compress_stock& c) {
     for (int i = 0; i < c.stocks.size(); i++) {
-      o << c.stocks[i] << ' ';
+      o << c.stocks[i];  // Fix space at beginning of lines
     }
     return o << '\n';
+  }
+
+  // Creates output stream and writes each Stock
+  friend void binwrite(const char* filename, const Compress_stock& c) {
+    ofstream stream(filename, ios::binary);
+    for (const auto& elem : c.stocks) {
+      binwrite(stream, elem);
+    }
   }
 };
 
@@ -115,4 +143,5 @@ int main() {
   const Compress_stock c("aapl.txt");
   ofstream outfile("aapl_delta.txt");
   outfile << c;
+  binwrite("aapl_delta.bin", c);
 }


### PR DESCRIPTION
launch.json:

launch.json now has a proper configuration for testing on Windows. Run
the 'g++ - run a.exe' task after running 'g++ -g <file>' to compile the
file to use VSCode's built-in debugger. This version currently requires
that the matching *.cpp file be open.

stock_delta.cpp:

A tldr (too long, didn't read) version of the following information is
present as comments in stock_delta.cpp

Stock no longer has a bit flag, to prevent underflow errors and save a
character per stock.

Minor bugs were fixed in the Stock constructor. These bugs should have
had no effect given that we overwrite the values most of the time, but
the fix was implemented just in case.

The first_day flag is now explicitly set every time new info is read
into a Stock object. This issue became incredibly apparent when the
tests we're running assumed that every Stock was a first stock, since
each stock shares a Stock object.

The delta function now accepts Stock pointers instead of Stocks, as
doing so allows us to default to nullptr.

The binwrite function was added to allow Compressed_stocks and Stocks to
be written directly to a binary file.